### PR TITLE
fix: correct asset paths for GitHub Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,17 +2,18 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/TaskFlow/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>TaskFlow - Modern Task Management App</title>
     <meta name="description" content="A modern, intuitive task management application built with React, TypeScript, and Tailwind CSS" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <script type="module" crossorigin src="/assets/index-Cnf6VbXb.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-D8P88eRj.css">
+    <script type="module" crossorigin src="/TaskFlow/assets/index-Cnf6VbXb.js"></script>
+    <link rel="stylesheet" crossorigin href="/TaskFlow/assets/index-D8P88eRj.css">
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root"></div>
+
   </body>
 </html>


### PR DESCRIPTION
This PR fixes the asset paths in index.html to work correctly with GitHub Pages deployment.

## Problem:
Assets were being loaded from /assets/... instead of /TaskFlow/assets/..., causing 404 errors.

## Solution:
- Added /TaskFlow/ prefix to all asset paths in docs/index.html
- Fixed CSS file reference: /assets/index-D8P88eRj.css â†’ /TaskFlow/assets/index-D8P88eRj.css
- Fixed JS file reference: /assets/index-Cnf6VbXb.js â†’ /TaskFlow/assets/index-Cnf6VbXb.js
- Fixed favicon path: /vite.svg â†’ /TaskFlow/vite.svg

## Result:
GitHub Pages will now correctly load all assets and the TaskFlow application will display properly at https://ohugods.github.io/TaskFlow/